### PR TITLE
fix: remove errant comma causing a parse error

### DIFF
--- a/includes/Block/class-issuearchive.php
+++ b/includes/Block/class-issuearchive.php
@@ -39,7 +39,7 @@ class IssueArchive extends \Newspack\Govpack\Block {
 				'supports'        => [
 					'customClassName' => false,
 				],
-			],
+			]
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the errant comma that causes a parse error

Closes #41 .

### How to test the changes in this Pull Request:

1. Activate the plugin and reload the admin Plugins screen
2. Observe the WordPress error screen, and parse error in the log
3. Apply the patch and refresh the page
4. No more error!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
