### PR TITLE
Use warning so all error messages get printed out

### DIFF
--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -115,7 +115,7 @@ class CLI extends \WP_CLI_Command {
 			if ( is_wp_error( $result ) ) {
 				foreach ( $result->errors as $error_info ) {
 					foreach ( $error_info as $message ) {
-						WP_CLI::error( $message );
+						WP_CLI::warning( $message );
 					}
 				}
 			}


### PR DESCRIPTION
`WP_CLI::error()` will kill execution so used in a loop like this will mean only the very first iteration of the loop will complete. Warning instead allows all the error messages to be printed and there is no more code to execute after the loop anyway.