### PR TITLE
fix: check for null post before updating

### DIFF
--- a/src/blocks/Profile.php
+++ b/src/blocks/Profile.php
@@ -25,18 +25,21 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 	protected $plugin;
 
 	public function __construct( $plugin ) {
-		
+
 		$this->plugin = $plugin;
 		//add_filter( 'render_block_context', [$this, 'modify_context'], 10, 3);
 		//add_filter( 'render_block_data', [$this, 'modify_block_data'], 10, 3);
-		add_filter( 'pre_render_block', [ $this, 'pre_render_block' ], 10, 3 ); 
+		add_filter( 'pre_render_block', [ $this, 'pre_render_block' ], 10, 3 );
 	}
 
 	public function pre_render_block( $pre_render, $parsed_block, $parent_block ) {
 		global $post;
 
 		if ( is_null( $pre_render ) && ( isset( $parsed_block['attrs']['postId'] ) ) ) {
-			$post = get_post( $parsed_block['attrs']['postId'] );
+			$new_post = get_post( $parsed_block['attrs']['postId'] );
+			if ( ! is_null( $new_post ) ) {
+				$post = $new_post;
+			}
 		}
 
 		return $pre_render;
@@ -61,7 +64,7 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 		}
 
 		$parsed_block['attrs']['postId'] = $parsed_block['attrs']['profileId'];
-		
+
 
 		return $parsed_block;
 	}
@@ -82,19 +85,19 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 	public function block_build_path(): string {
 		return $this->plugin->build_path( 'blocks/Profile' );
 	}
-	
+
 	public function filter_kses_for_svg($tags, $context){
 		if($context !== "post"){
 			return $tags;
 		}
-		
+
 		$tags = \array_merge($tags, [
 			'svg'      => [
-				'xmlns'   => [], 
-				'width'   => [], 
-				'height'  => [], 
+				'xmlns'   => [],
+				'width'   => [],
+				'height'  => [],
 				'viewbox' => [], //lowercase not camelcase!
-			], 
+			],
 			'path'     => [
 				'd' => [],
 			],
@@ -127,7 +130,7 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 
 		global $post;
 
-	
+
 		if ( ! isset( $attributes['postId'] ) || ( ! $attributes['postId'] ) ) {
 			return;
 		}
@@ -138,14 +141,14 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 
 		$this->profile = \Govpack\Profile\Profile::get( $attributes['postId'] );
 
-		
-		
+
+
 		if ( ! $this->profile ) {
 			return;
 		}
 
 		$this->allow_svg_in_wp_kses();
-	
+
 		$this->attributes = self::merge_attributes_with_block_defaults( $this->block_name, $attributes );
 		$this->enqueue_view_assets();
 
@@ -165,11 +168,11 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 	 * @param WP_Block $template The filename of the template-part to use.
 	 */
 	public function handle_render( array $attributes, string $content, WP_Block $block ) {
-		
+
 		$tag_name = $this->attributes['tagName'] ?? 'div';
-		
+
 		$block_html = sprintf(
-			'<%s %s>%s</%s>', 
+			'<%s %s>%s</%s>',
 			$tag_name,
 			get_block_wrapper_attributes(
 				$this->get_new_block_wrapper_attributes()
@@ -178,12 +181,12 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 			$content,
 			$tag_name
 		);
-		
+
 		echo  wp_kses_post($block_html);
 	}
 
-	
-	
+
+
 	public function template(): string {
 		return sprintf( 'blocks/%s', $this->template );
 	}
@@ -195,19 +198,19 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 
 
 		if ( isset( $this->attributes['align'] ) && $this->attributes['customWidth'] ) {
-			
+
 			$styles['max-width'] = $this->attributes['customWidth'];
 		}
 
 		if ( ! empty( $styles ) ) {
 			$new_attrs['style'] = trim(
 				implode(
-					' ', 
+					' ',
 					array_map(
 						function ( $rule, $value ) {
 							return sprintf( '%s: %s;', $rule, $value );
-						}, 
-						array_keys( $styles ), 
+						},
+						array_keys( $styles ),
 						array_values( $styles )
 					)
 				)
@@ -215,11 +218,11 @@ class Profile extends \Govpack\Blocks\LegacyProfile {
 		}
 
 		$classes = apply_filters( 'newspack_elections_profile_block_classes', $this->get_wrapper_classes() );
-		
+
 		if ( ! empty( $classes ) ) {
 			$new_attrs['class'] = trim( implode( ' ', $classes ) );
 		}
-		
+
 		return $new_attrs;
 	}
 


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/NPPM-2650/texas-tribune-some-posts-get-the-global-dollarpost-nullified-somewhere

`get_post` can return `null` and when it does, the result is global `$post` is nullified. This ends up causing issues for any other extension that relies on this global after the `pre_render_block` hook fires.

**Testing Instructions**
Code review should be enough, but smoke testing election profiles to ensure there are no regressions would be a bonus.

Note: sorry about all the spacing changes, my editor auto applied them. Let me know if you'd like me to remove this noise.