### PR TITLE
fix: install compatible wp-cli/dist-archive-command version

### DIFF
--- a/.github/actions/wp-cli-dist-archive/action.yml
+++ b/.github/actions/wp-cli-dist-archive/action.yml
@@ -7,7 +7,7 @@ outputs:
   filename:
    description: "Name of the Generate Archive"
    value: ${{ steps.get-file-name.outputs.filename }}
-inputs: 
+inputs:
   path:
     required: false
     description: "Path to the project that includes a .distignore file."
@@ -37,7 +37,7 @@ runs:
         sudo mv wp-cli.phar /usr/local/bin/wp
       shell: bash
     - name: Install Dist Archive Command for WP CLI
-      run: wp package install wp-cli/dist-archive-command
+      run: wp package install wp-cli/dist-archive-command:v3.1.0
       shell: bash
     - name: Generate the Archive
       id: generate-archive

--- a/newspack-elections.php
+++ b/newspack-elections.php
@@ -7,8 +7,8 @@
  * Author URI:        https://automattic.com/
  * Text Domain:       newspack-elections
  * Domain Path:       /languages
- * Version:           2.0.0
- * Requires at least: 6.7 
+ * Version:           2.0.1
+ * Requires at least: 6.7
  * License:           GPL2
  *
  * @package         Newspack_Elections


### PR DESCRIPTION
See p1774961623031999/1774625153.416989-slack-C087EFPR2TG

This PR addresses an issue where the `wp-cli/dist-archive-command` is not installable due to a required wp-cli version constraint. 