### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/npm
 
       - name: Extract Git Tag Version Info (eg -rc*, -dev, -alpha)
-        uses: olegtarasov/get-tag@v2.1.3
+        uses: olegtarasov/get-tag@45e6ac666e58c4737f7f0d22a2aabf67a7b36c0d # 2.1.3
         id: tagVersion
         with:
           tagRegex: "-(.*)"  # Optional. Returns specified group text as tag name. Full tag string is returned if regex is not defined.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,14 @@ jobs:
         uses: ./.github/actions/npm
 
       - name: Extract Git Tag Version Info (eg -rc*, -dev, -alpha)
-        uses: olegtarasov/get-tag@v2.1.3
+        uses: olegtarasov/get-tag@45e6ac666e58c4737f7f0d22a2aabf67a7b36c0d # 2.1.3
         id: tagVersion
         with:
           tagRegex: "-(.*)"  # Optional. Returns specified group text as tag name. Full tag string is returned if regex is not defined.
           tagRegexGroup: 1 # Optional. Default is 1.
         
       - name: Extract Git Tag Version Info (eg -rc*, -dev, -alpha)
-        uses: olegtarasov/get-tag@v2.1.3
+        uses: olegtarasov/get-tag@45e6ac666e58c4737f7f0d22a2aabf67a7b36c0d # 2.1.3
         id: tag
 
       - name: Extracted version
@@ -69,7 +69,7 @@ jobs:
       #  if: ${{steps.tagVersion.outputs.tag != ''}}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 2
- Repo-level unpinned usage count from the trunk recheck: 4
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# olegtarasov/get-tag # 2.1.3 -> 45e6ac666e58c4737f7f0d22a2aabf67a7b36c0d
gh api repos/olegtarasov/get-tag/commits/2.1.3 --jq '.sha'
# expected: 45e6ac666e58c4737f7f0d22a2aabf67a7b36c0d

# softprops/action-gh-release # v2.6.2 -> 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
gh api repos/softprops/action-gh-release/commits/v2.6.2 --jq '.sha'
# expected: 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
```
