### PR TITLE
Cover composite actions in Dependabot github-actions config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" covers .github/workflows + root action.yml only; the glob adds the
+    # nested composite actions (.github/actions/*/action.yml).
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Follow-up to the DEVPROD-1072 SHA-pinning PR (#62).

Dependabot's `github-actions` ecosystem with `directory: "/"` scans `.github/workflows/` plus a root `action.yml` only — **not** nested composite actions ([options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)). This repo's `.github/actions/composer/action.yml` and `.github/actions/npm/action.yml` reference `actions/cache@v4`, which would never receive Dependabot update PRs.

Switches the entry to the `directories` key with a glob (`/` + `/.github/actions/*`), covering current and future composite actions. Config-only; no workflow behaviour change.