### PR TITLE
Only enqueue editor scripts in admin

### DIFF
--- a/includes/Blocks.php
+++ b/includes/Blocks.php
@@ -27,17 +27,15 @@ class Blocks {
 	 * Register Block Assets.
 	 */
 	public function enqueue_block_assets(): void {
-		
-
-		$this->register_script( 'npe-editor', 'npe-editor' );
-		wp_enqueue_script( 'npe-editor' );
+		if ( is_admin() ) {
+			$this->register_script( 'npe-editor', 'npe-editor' );
+			wp_enqueue_script( 'npe-editor' );
+			$this->register_style( 'npe-blocks-editor-style', 'npe-blocks' );
+			wp_enqueue_style( 'npe-blocks-editor-style' );
+		}
 
 		$this->register_script( 'npe-blocks', 'npe-blocks' );
 		wp_enqueue_script( 'npe-blocks' );
-
-		$this->register_style( 'npe-blocks-editor-style', 'npe-blocks' );
-		wp_enqueue_style( 'npe-blocks-editor-style' );
-
 		$this->register_style( 'npe-blocks-shared-styles', 'profile-shared-styles' );
 	}
 


### PR DESCRIPTION
**Note: This is a patch for v2.0.x**

Fixes a big performance issue in Newspack Elections — it enqueues the block editor JS on the frontend, which is wasteful but also creates an API call to the /users/me REST API endpoint on every single pageview, as well as possibly other API endpoints.

1. Before applying this PR, visit the site frontend with the network inspector open in an incognito window. Observe an API request to `/users/me` which throws a 401 status (since user is not logged in). View page source and observe a bunch of editor JS files.
2. Apply this patch. Visit the frontend again in a new incognito window. Observe no API request and no editor JS files.